### PR TITLE
Update SEM dataset to BEP031 v0.0.5

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,7 @@
 # data_axondeepseg_sem
-SEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
 
+SEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
 10 rat spinal cord samples with axon and myelin manual segmentation labels.
 
 Example dataset containing scanning electron microscopy (SEM) data to illustrate BIDS convention.
-
 BIDS version 1.6.0 - Microscopy BEP031 version 0.0.5 (2021-09-07T14:20:00)

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ SEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
 
 Example dataset containing scanning electron microscopy (SEM) data to illustrate BIDS convention.
 
-BIDS version 1.6.0 - Microscopy BEP031 version 0.0.4 (2021-07-13T15:14:00)
+BIDS version 1.6.0 - Microscopy BEP031 version 0.0.5 (2021-09-07T14:20:00)

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -1,7 +1,17 @@
 {
 	"Name": "data_axondeepseg_sem",
 	"BIDSVersion": "1.6.0 - BEP031 v0.0.5",
-	"Authors": "List of individuals who contributed to the creation/curation of the dataset.",
-	"HowToAcknowledge": "Text containing instructions on how researchers using this dataset should acknowledge the original authors. This field can also be used to define a publication that should be cited in publications that use the dataset.",
+	"Authors": ["Pierre-Louis Antonsanti",
+	            "Marie-Hélène Bourget",
+	            "Julien Cohen-Adad",
+	            "Tanguy Duval",
+	            "Alexandru Foias",
+	            "Victor Herman",
+	            "Nafisa Husein",
+	            "Harris Nami",
+	            "Christian S. Perone",
+	            "Ariane Saliani",
+	            "Maxime Wabartha",
+	            "Aldo Zaimi"],
 	"License": "MIT"
 }

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -1,5 +1,7 @@
 {
 	"Name": "data_axondeepseg_sem",
-	"BIDSVersion":"1.6.0 - BEP031 v0.0.4",
+	"BIDSVersion": "1.6.0 - BEP031 v0.0.5",
+	"Authors": "List of individuals who contributed to the creation/curation of the dataset.",
+	"HowToAcknowledge": "Text containing instructions on how researchers using this dataset should acknowledge the original authors. This field can also be used to define a publication that should be cited in publications that use the dataset.",
 	"License": "MIT"
 }

--- a/derivatives/labels/dataset_description.json
+++ b/derivatives/labels/dataset_description.json
@@ -1,5 +1,5 @@
 {
 	"Name": "data_axondeepseg_sem labels",
-	"BIDSVersion": "1.6.0 - BEP031 v0.0.4",
+	"BIDSVersion": "1.6.0 - BEP031 v0.0.5",
 	"PipelineDescription": {"Name": "Axon and myelin manual segmentation labels"}
 }

--- a/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
+++ b/sub-rat1/microscopy/sub-rat1_sample-data1_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.18, 0.18],
-    "FieldOfView": [230, 166],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 2% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
+++ b/sub-rat2/microscopy/sub-rat2_sample-data5_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.093, 0.093],
-    "FieldOfView": [119, 89],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "4% paraformaldehyde, 0% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat3/microscopy/sub-rat3_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.1, 0.1],
-    "FieldOfView": [77, 84],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data10_SEM.json
@@ -1,7 +1,0 @@
-{
-    "PixelSize": [0.1, 0.1],
-    "FieldOfView": [74, 76],
-    "BodyPart": "CSPINE",
-    "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Environment": "exvivo"
-}

--- a/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
+++ b/sub-rat3/microscopy/sub-rat3_sample-data9_SEM.json
@@ -1,7 +1,0 @@
-{
-    "PixelSize": [0.1, 0.1],
-    "FieldOfView": [76, 76],
-    "BodyPart": "CSPINE",
-    "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
-    "Environment": "exvivo"
-}

--- a/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
+++ b/sub-rat4/microscopy/sub-rat4_sample-data12_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.1, 0.1],
-    "FieldOfView": [82, 77],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
+++ b/sub-rat5/microscopy/sub-rat5_sample-data14_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.13, 0.13],
-    "FieldOfView": [247, 234],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
+++ b/sub-rat6/microscopy/sub-rat6_sample-data15_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.13, 0.13],
-    "FieldOfView": [150, 97],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"

--- a/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
+++ b/sub-rat7/microscopy/sub-rat7_sample-Maxo03img60_SEM.json
@@ -1,5 +1,5 @@
 {
     "PixelSize": [0.07, 0.07],
-    "FieldOfView": [140, 140],
+    "PixelSizeUnits": "um",
     "Environment": "exvivo"
 }

--- a/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
+++ b/sub-rat8/microscopy/sub-rat8_sample-V915_SEM.json
@@ -1,6 +1,6 @@
 {
     "PixelSize": [0.07, 0.07],
-    "FieldOfView": [108, 77],
+    "PixelSizeUnits": "um",
     "BodyPart": "CSPINE",
     "SampleFixation": "3% paraformaldehyde, 3% glutaraldehyde",
     "Environment": "exvivo"


### PR DESCRIPTION
This PR updates the axondeepseg dataset to the Microscopy BEP031 version 0.0.5 (last version on google drive) to be incorporated as an example in main the BEP031 PR to the bids-specification.