### PR TITLE
Add Zenodo DOI

### DIFF
--- a/dataset_description.json
+++ b/dataset_description.json
@@ -1,6 +1,7 @@
 {
 	"Name": "data_axondeepseg_sem",
 	"BIDSVersion": "1.6.0 - BEP031 v0.0.5",
+	"License": "MIT",
 	"Authors": ["Pierre-Louis Antonsanti",
 	            "Marie-Hélène Bourget",
 	            "Julien Cohen-Adad",
@@ -13,5 +14,5 @@
 	            "Ariane Saliani",
 	            "Maxime Wabartha",
 	            "Aldo Zaimi"],
-	"License": "MIT"
+	"DatasetDOI": "doi:10.5281/zenodo.5498378"
 }


### PR DESCRIPTION
This PR adds the new Zenodo DOI to dataset_description.json.

Thanks @jcohenadad, the Zenodo idea is perfect. So the new release is done, the permanent DOI (to always cite the latest version) is https://doi.org/10.5281/zenodo.5498378.

One the PR is approve, I'll redo a release tomorrow. Thanks!