### PR TITLE
Final modifications before DANDI upload

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,28 @@
+The following is a high-level summary of the changes this dataset underwent
+over the years, based on its git history.
+
+0.06 2025-04-30
+
+- Modify masks for 6/10 samples to separate fibers with a 1 px delineation
+
+- Update author list and README
+
+0.05 2021-11-30
+
+- Update dataset after BEP031 community review
+
+0.04 2021-09-13
+
+- Add DOI
+
+0.03 2021-07-15
+
+- Enrich metadata
+
+0.02 2020-10-08
+
+- Format according to BIDS structure
+
+0.01 2020-07-21
+
+- Initial data upload

--- a/README
+++ b/README
@@ -1,7 +1,14 @@
 # data_axondeepseg_sem
 
 SEM dataset for AxonDeepSeg (https://axondeepseg.readthedocs.io/)
-10 rat spinal cord samples with axon and myelin manual segmentation labels. This dataset comprises acquisitions conducted by various researchers between 2015 and 2017. The images represent small cropped sections extracted from larger mosaic images.
+
+- 10 rat spinal cord samples (cervical level) with axon and myelin manual segmentation labels.
+
+- Isotropic pixel size resolution ranging from 0.05 to 0.18 um
+
+- Every touching fiber is separated by a 1 pixel delineation in the masks.
+
+- This dataset comprises acquisitions conducted by various researchers between 2015 and 2017. The images represent small cropped sections extracted from larger mosaic images.
 
 Example dataset containing scanning electron microscopy (SEM) data to illustrate BIDS convention.
 BIDS version 1.7.0

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -13,6 +13,6 @@
 	            "Christian S. Perone",
 	            "Ariane Saliani",
 	            "Maxime Wabartha",
-				"Armand Collin",
+	            "Armand Collin",
 	            "Julien Cohen-Adad"]
 }

--- a/dataset_description.json
+++ b/dataset_description.json
@@ -14,6 +14,5 @@
 	            "Ariane Saliani",
 	            "Maxime Wabartha",
 				"Armand Collin",
-	            "Julien Cohen-Adad"],
-	"DatasetDOI": "doi:10.5281/zenodo.5498378"
+	            "Julien Cohen-Adad"]
 }


### PR DESCRIPTION
This morning, it was established that we will upload the SEM dataset on DANDI instead of continuing forward with zotero, in an effort to centralize everything.

This PR includes 2 small changes:
- removed zenodo DOI from `dataset_description.json` 
- added changelog